### PR TITLE
Remove EarthEngine description check and most recent model functionality

### DIFF
--- a/openmapflow/config.py
+++ b/openmapflow/config.py
@@ -78,7 +78,7 @@ class BucketNames:
 
 
 def get_model_names_as_str() -> str:
-    """Get the names of the most recent models as a string."""
+    """Get the names of all models as a string."""
     models = [Path(p).stem for p in Path(PROJECT_ROOT / DataPaths.MODELS).glob("*.pt")]
     return " ".join(models)
 

--- a/openmapflow/config.py
+++ b/openmapflow/config.py
@@ -78,12 +78,10 @@ class BucketNames:
     PREDS_MERGED = CONFIG_YML["gcloud"]["bucket_preds_merged"]
 
 
-def get_model_names_as_str(most_recent: int = 3) -> str:
+def get_model_names_as_str() -> str:
     """Get the names of the most recent models as a string."""
-    model_files = [p for p in Path(PROJECT_ROOT / DataPaths.MODELS).glob("*.pt")]
-    model_files.sort(key=os.path.getmtime)
-    latest_models = [Path(m).stem for m in model_files[-most_recent:]]
-    return " ".join(latest_models)
+    models = [Path(p).stem for p in Path(PROJECT_ROOT / DataPaths.MODELS).glob("*.pt")]
+    return " ".join(models)
 
 
 def deploy_env_variables(empty_check: bool = True) -> str:

--- a/openmapflow/config.py
+++ b/openmapflow/config.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Dict

--- a/openmapflow/ee_exporter.py
+++ b/openmapflow/ee_exporter.py
@@ -156,10 +156,6 @@ class EarthEngineExporter:
         ):
             return True
 
-        # Check if task is already started in EarthEngine
-        if description in self.ee_task_list:
-            return True
-
         if len(self.ee_task_list) >= 3000:
             return False
 

--- a/openmapflow/scripts/deploy.sh
+++ b/openmapflow/scripts/deploy.sh
@@ -17,11 +17,14 @@ env | grep OPENMAPFLOW
 echo "2/8 Ensuring latest models are available for deployment"
 dvc pull "$OPENMAPFLOW_MODELS_DIR".dvc -f
 
-export OPENMAPFLOW_MODELS=$(
-        python -c \
-        "from openmapflow.config import get_model_names_as_str; \
-        print(get_model_names_as_str())"
-)
+if [[ -z "$OPENMAPFLOW_MODELS" ]]; then
+        export OPENMAPFLOW_MODELS=$(
+                python -c \
+                "from openmapflow.config import get_model_names_as_str; \
+                print(get_model_names_as_str())"
+        )
+fi
+
 echo "MODELS: $OPENMAPFLOW_MODELS"
 
 echo "3/8 Enable Google Cloud APIs: Artifact Registry, Cloud Run, Cloud Functions"


### PR DESCRIPTION
**1. EarthEngine code bug**
BEFORE: EarthEngine task description was assumed to be unique and used to avoid relaunching the same task. 
AFTER: The description will not always be unique because it is capped at 100 characters which means it cannot be used to avoid relaunching the same task. So this code is removed while a better solution is investigated.

**2. Deploy most recent models bug**
BEFORE: Deploys most 3 most recent model files, however if dvc pulled the file age could not be calculated.
AFTER: Deploys all models by default and exposes `OPENMAPFLOW_MODELS` env variable to deploy a subset of models