### PR TITLE
Gdal workaround for build VRT and translate

### DIFF
--- a/openmapflow/notebooks/create_map.ipynb
+++ b/openmapflow/notebooks/create_map.ipynb
@@ -29,6 +29,24 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Downgrade gdal \n",
+        "%%shell\n",
+        "yes | add-apt-repository ppa:ubuntugis/ppa\n",
+        "apt-get update\n",
+        "apt-get install python3-gdal=3.0.4+dfsg-1build3\n",
+        "apt-get install gdal-bin=3.0.4+dfsg-1build3\n",
+        "apt-get install libgdal-dev=3.0.4+dfsg-1build3\n",
+        "C_INCLUDE_PATH=/usr/include/gdal \n",
+        "CPLUS_INCLUDE_PATH=/usr/include/gdal \n",
+        "python -m pip install GDAL==3.0.4"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "R9nTgKE1qU1a"
       },
@@ -83,7 +101,8 @@
         "    get_available_models\n",
         ")\n",
         "warnings.simplefilter(action='ignore', category=FutureWarning)\n",
-        "print(PROJECT)"
+        "print(PROJECT)\n",
+        "os.environ[\"GCLOUD_PROJECT\"] = GCLOUD_PROJECT_ID"
       ]
     },
     {
@@ -311,6 +330,21 @@
       "outputs": [],
       "source": [
         "build_vrt(prefix)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Upgrade gdal to 3.3.2\n",
+        "%%shell\n",
+        "apt-get install gdal-bin\n",
+        "apt-get install libgdal-dev\n",
+        "C_INCLUDE_PATH=/usr/include/gdal \n",
+        "CPLUS_INCLUDE_PATH=/usr/include/gdal \n",
+        "python -m pip install GDAL==3.3.2"
       ]
     },
     {


### PR DESCRIPTION
Workaround for mosaicking `.nc` prediction files that is broken since GColab updated pre-installed GDAL from 3.0.4 to 3.3.2 in 2/17/23 update.  