### PR TITLE
Remove gdal pip install

### DIFF
--- a/openmapflow/notebooks/create_map.ipynb
+++ b/openmapflow/notebooks/create_map.ipynb
@@ -38,10 +38,7 @@
         "apt-get update\n",
         "apt-get install python3-gdal=3.0.4+dfsg-1build3\n",
         "apt-get install gdal-bin=3.0.4+dfsg-1build3\n",
-        "apt-get install libgdal-dev=3.0.4+dfsg-1build3\n",
-        "C_INCLUDE_PATH=/usr/include/gdal \n",
-        "CPLUS_INCLUDE_PATH=/usr/include/gdal \n",
-        "python -m pip install GDAL==3.0.4"
+        "apt-get install libgdal-dev=3.0.4+dfsg-1build3"
       ]
     },
     {
@@ -341,10 +338,7 @@
         "# Upgrade gdal to 3.3.2\n",
         "%%shell\n",
         "apt-get install gdal-bin\n",
-        "apt-get install libgdal-dev\n",
-        "C_INCLUDE_PATH=/usr/include/gdal \n",
-        "CPLUS_INCLUDE_PATH=/usr/include/gdal \n",
-        "python -m pip install GDAL==3.3.2"
+        "apt-get install libgdal-dev"
       ]
     },
     {


### PR DESCRIPTION
Removes pip install of `gdal` in the cells downgrading/upgrading `gdal` - instead only need binaries. 

