### PR TITLE
Fix off by one error in inference.py

### DIFF
--- a/openmapflow/inference.py
+++ b/openmapflow/inference.py
@@ -83,7 +83,7 @@ class Inference:
 
         batches = [
             x_np[i : i + self.batch_size]  # noqa: E203
-            for i in range(0, (x_np.shape[0] - 1), self.batch_size)
+            for i in range(0, x_np.shape[0], self.batch_size)
         ]
         batch_predictions = [self._on_single_batch(b) for b in batches]
         combined_pred = self._combine_predictions(flat_lat, flat_lon, batch_predictions)


### PR DESCRIPTION
Currently, the inference will miss a prediction (and fail during dataframe creation) if `x_np.shape[0] % batch_size == 1`. 

This PR fixes that. Specifically:

```python
>>> import numpy as np
>>> total_size, batch_size = 1185857, 64
>>> x_np = np.ones(total_size)
>>> # current approach
>>> batches = [x_np[i : i + batch_size] for i in range(0, x_np.shape[0] - 1, batch_size)]
>>> sum([len(x) for x in batches])
1185856
>>> # fixed
>>> batches = [x_np[i : i + batch_size] for i in range(0, x_np.shape[0], batch_size)]
>>> sum([len(x) for x in batches])
1185857
```